### PR TITLE
Breaking changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.psci*
 package-lock.json
 .psc-package
+.spago

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,0 +1,128 @@
+{-
+Welcome to your new Dhall package-set!
+
+Below are instructions for how to edit this file for most use
+cases, so that you don't need to know Dhall to use it.
+
+## Warning: Don't Move This Top-Level Comment!
+
+Due to how `dhall format` currently works, this comment's
+instructions cannot appear near corresponding sections below
+because `dhall format` will delete the comment. However,
+it will not delete a top-level comment like this one.
+
+## Use Cases
+
+Most will want to do one or both of these options:
+1. Override/Patch a package's dependency
+2. Add a package not already in the default package set
+
+This file will continue to work whether you use one or both options.
+Instructions for each option are explained below.
+
+### Overriding/Patching a package
+
+Purpose:
+- Change a package's dependency to a newer/older release than the
+    default package set's release
+- Use your own modified version of some dependency that may
+    include new API, changed API, removed API by
+    using your custom git repo of the library rather than
+    the package set's repo
+
+Syntax:
+Replace the overrides' "{=}" (an empty record) with the following idea
+The "//" or "⫽" means "merge these two records and
+  when they have the same value, use the one on the right:"
+-------------------------------
+let override =
+  { packageName =
+      upstream.packageName // { updateEntity1 = "new value", updateEntity2 = "new value" }
+  , packageName =
+      upstream.packageName // { version = "v4.0.0" }
+  , packageName =
+      upstream.packageName // { repo = "https://www.example.com/path/to/new/repo.git" }
+  }
+-------------------------------
+
+Example:
+-------------------------------
+let overrides =
+  { halogen =
+      upstream.halogen // { version = "master" }
+  , halogen-vdom =
+      upstream.halogen-vdom // { version = "v4.0.0" }
+  }
+-------------------------------
+
+### Additions
+
+Purpose:
+- Add packages that aren't already included in the default package set
+
+Syntax:
+Replace the additions' "{=}" (an empty record) with the following idea:
+-------------------------------
+let additions =
+  { "package-name" =
+       { dependencies =
+           [ "dependency1"
+           , "dependency2"
+           ]
+       , repo =
+           "https://example.com/path/to/git/repo.git"
+       , version =
+           "tag ('v4.0.0') or branch ('master')"
+       }
+  , "package-name" =
+       { dependencies =
+           [ "dependency1"
+           , "dependency2"
+           ]
+       , repo =
+           "https://example.com/path/to/git/repo.git"
+       , version =
+           "tag ('v4.0.0') or branch ('master')"
+       }
+  , etc.
+  }
+-------------------------------
+
+Example:
+-------------------------------
+let additions =
+  { benchotron =
+      { dependencies =
+          [ "arrays"
+          , "exists"
+          , "profunctor"
+          , "strings"
+          , "quickcheck"
+          , "lcg"
+          , "transformers"
+          , "foldable-traversable"
+          , "exceptions"
+          , "node-fs"
+          , "node-buffer"
+          , "node-readline"
+          , "datetime"
+          , "now"
+          ],
+      , repo =
+          "https://github.com/hdgarrood/purescript-benchotron.git"
+      , version =
+          "v7.0.0"
+      }
+  }
+-------------------------------
+-}
+
+
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.3-20190831/packages.dhall sha256:852cd4b9e463258baf4e253e8524bcfe019124769472ca50b316fe93217c3a47
+
+let overrides = {=}
+
+let additions = {=}
+
+in  upstream // overrides // additions

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,0 +1,20 @@
+{-
+Welcome to a Spago project!
+You can edit this file as you like.
+-}
+{ name =
+    "halogen-svg"
+, dependencies =
+    [ "console"
+    , "effect"
+    , "halogen"
+    , "prelude"
+    , "psci-support"
+    , "strings"
+    , "web-uievents"
+    ]
+, packages =
+    ./packages.dhall
+, sources =
+    [ "src/**/*.purs", "test/**/*.purs" ]
+}

--- a/src/Svg/Attributes.purs
+++ b/src/Svg/Attributes.purs
@@ -2,223 +2,14 @@ module Svg.Attributes where
 -- Like Halogen.HTML.Properties
 
 import Prelude
-import Data.Maybe (Maybe(..), maybe)
-import Data.String (joinWith, toUpper)
 
 import Core as Core
-
+import Data.Maybe (Maybe(..), maybe)
+import Data.String (joinWith)
 import Halogen.HTML.Core (Prop, AttrName(AttrName), Namespace(Namespace))
 import Halogen.HTML.Properties (IProp, attrNS)
+import Svg.Types (Align, printAlign, MeetOrSlice, printMeetOrSlice, PaintServer, StrokeLinecap, Transform, printTransform, D, printD, TextAnchor, printTextAnchor, FontSize, Baseline, printBaseline, Orient, printOrient, MarkerUnit, printMarkerUnit, PatternUnits, Point)
 import Unsafe.Coerce (unsafeCoerce)
-
-data Color = RGB Int Int Int
-           | RGBA Int Int Int Number
-
-printColor :: Color -> String
-printColor (RGB r' g' b') = "rgb(" <> (joinWith "," $ map show [r', g', b']) <> ")"
-printColor (RGBA r' g' b' o') = "rgba(" <> (joinWith "," $ map show [r', g', b']) <> "," <> show o' <> ")"
-
-data PaintServer
-  = PaintNone
-  | PaintColor Color
-  | Pattern String
-  | Gradient String
-  | Hatch String
-printPaintServer :: PaintServer -> String
-printPaintServer PaintNone = "None"
-printPaintServer (PaintColor color) = printColor color
-printPaintServer (Pattern pattern) = pattern
-printPaintServer (Gradient gradient) = gradient
-printPaintServer (Hatch hatch) = hatch
-
-data Transform
-  = Matrix Number Number Number Number Number Number
-  | Translate Number Number
-  | Scale Number Number
-  | Rotate Number Number Number
-  | SkewX Number
-  | SkewY Number
-
-data TextAnchor = Start | AnchorMiddle | End
-
-data CSSLength
-  = Cm Number
-  | Mm Number
-  | Inches Number
-  | Px Number
-  | Pt Number
-  | Pc Number
-  | Em Number
-  | Ex Number
-  | Rem Number
-  | Vw Number
-  | Vh Number
-  | Vmin Number
-  | Vmax Number
-  | Pct Number
-  | Nil
-
-instance showCSSLength :: Show CSSLength where
-  show (Cm i) = (show i) <> "cm"
-  show (Mm i) = (show i) <> "mm"
-  show (Inches i) = (show i) <> "in"
-  show (Px i) = (show i) <> "px"
-  show (Pt i) = (show i) <> "pt"
-  show (Pc i) = (show i) <> "pc"
-  show (Em i) = (show i) <> "em"
-  show (Ex i) = (show i) <> "ex"
-  show (Rem i) = (show i) <> "rem"
-  show (Vw i) = (show i) <> "vw"
-  show (Vh i) = (show i) <> "vh"
-  show (Vmin i) = (show i) <> "vmin"
-  show (Vmax i) = (show i) <> "vmax"
-  show (Pct i) = (show i) <> "%"
-  show Nil = "0"
-
-data FontSize
-  = XXSmall
-  | XSmall
-  | Small
-  | Medium
-  | Large
-  | XLarge
-  | XXLarge
-  | Smaller
-  | Larger
-  | FontSizeLength CSSLength
-
-data Orient
-  = AutoOrient
-  | AutoStartReverse
-
-instance showOrient :: Show Orient where
-  show AutoOrient = "auto"
-  show AutoStartReverse = "auto-start-reverse"
-
-printOrient :: Orient -> String
-printOrient AutoOrient = "auto"
-printOrient AutoStartReverse = "auto-start-reverse"
-
-data MarkerUnit
-  = UserSpaceOnUse
-  | StrokeWidth
-
-instance showMarkerUnit :: Show MarkerUnit where
-  show UserSpaceOnUse = "userSpaceOnUse"
-  show StrokeWidth = "strokeWidth"
-
-printMarkerUnit :: MarkerUnit -> String
-printMarkerUnit UserSpaceOnUse = "userSpaceOnUse"
-printMarkerUnit StrokeWidth = "strokeWidth"
-
-instance showFontSize :: Show FontSize where
-  show XXSmall = "xx-small"
-  show XSmall = "x-small"
-  show Small = "small"
-  show Medium = "medium"
-  show Large = "large"
-  show XLarge = "x-large"
-  show XXLarge = "xx-large"
-  show Smaller = "smaller"
-  show Larger = "larger"
-  show (FontSizeLength l) = show l
-
-printTextAnchor :: TextAnchor -> String
-printTextAnchor Start = "start"
-printTextAnchor AnchorMiddle = "middle"
-printTextAnchor End = "end"
-
-data Baseline
-  = Auto | UseScript | NoChange | ResetSize | Ideographic | Alphabetic | Hanging
-  | Mathematical | Central | BaselineMiddle | TextAfterEdge | TextBeforeEdge
-
-printBaseline :: Baseline -> String
-printBaseline Auto = "auto"
-printBaseline UseScript = "use-script"
-printBaseline NoChange = "no-change"
-printBaseline ResetSize = "reset-size"
-printBaseline Ideographic = "ideographic"
-printBaseline Alphabetic = "alphabetic"
-printBaseline Hanging = "hanging"
-printBaseline Mathematical = "mathematical"
-printBaseline Central = "central"
-printBaseline BaselineMiddle = "middle"
-printBaseline TextAfterEdge = "text-after-edge"
-printBaseline TextBeforeEdge = "text-before-edge"
-
-printTransform :: Transform -> String
-printTransform (Matrix a' b' c' d' e' f') =
-  "matrix(" <> (joinWith "," $ map show [a', b', c', d', e', f']) <> ")"
-printTransform (Translate x' y') = "translate(" <> (joinWith "," $ map show [x', y']) <> ")"
-printTransform (Scale x' y') = "scale(" <> (joinWith "," $ map show [x', y']) <> ")"
-printTransform (Rotate a' x' y') = "rotate(" <> (joinWith "," $ map show [a', x', y']) <> ")"
-printTransform (SkewX a') = "skewX(" <> show a' <> ")"
-printTransform (SkewY a') = "skewY(" <> show a' <> ")"
-
-data D = Rel Command | Abs Command
-printD :: D -> String
-printD (Abs cmd) = (toUpper p.command) <> p.params
-  where p = printCommand cmd
-printD (Rel cmd) = p.command <> p.params
-  where p = printCommand cmd
-
-data Command
-  = M Number Number
-  | L Number Number
-  | C Number Number Number Number Number Number
-  | S Number Number Number Number
-  | Q Number Number Number Number
-  | T Number Number
-  | A Number Number Number Boolean Boolean Number Number
-  | Z
-
-printCommand :: Command -> {command :: String, params :: String}
-printCommand (M x' y') = {command: "m", params: joinWith "," $ map show [x', y']}
-printCommand (L x' y') = {command: "l", params: joinWith "," $ map show [x', y']}
-printCommand (C x1' y1' x2' y2' x' y') =
-  {command: "c" , params: joinWith "," $ map show [x1', y1', x2', y2', x', y']}
-printCommand (S x2' y2' x' y') =
-  {command: "s" , params: joinWith "," $ map show [x2', y2', x', y']}
-printCommand (Q x1' y1' x' y') =
-  {command: "q" , params: joinWith "," $ map show [x1', y1', x', y']}
-printCommand (T x' y') = {command: "t", params: joinWith "," $ map show [x', y']}
-printCommand (A rx' ry' rot large sweep x' y') =
-  {command: "a", params: joinWith ","
-                 $ map show [ rx', ry', rot ]
-                 <> [ large_flag, sweep_flag ]
-                 <> map show [ x', y' ]}
-  where
-  large_flag = if large then "0" else "1"
-  sweep_flag = if sweep then "0" else "1"
-printCommand Z = {command: "z", params: ""}
-
-data Align = Min | Mid | Max
-
-printAlign :: Align -> String
-printAlign Min = "Min"
-printAlign Mid = "Mid"
-printAlign Max = "Max"
-
-data MeetOrSlice = Meet | Slice
-printMeetOrSlice :: MeetOrSlice -> String
-printMeetOrSlice Meet = "meet"
-printMeetOrSlice Slice = "slice"
-
-data StrokeLinecap
-  = Butt
-  | Round
-  | Square
-printStrokeLinecap :: StrokeLinecap -> String
-printStrokeLinecap Butt = "butt"
-printStrokeLinecap Round = "round"
-printStrokeLinecap Square = "square"
-
-data PatternUnits
-  = PatternUnitsUserSpaceOnUse
-  | ObjectBoundingBox
-printPatternUnits :: PatternUnits -> String
-printPatternUnits PatternUnitsUserSpaceOnUse = "userSpaceOnUse"
-printPatternUnits ObjectBoundingBox = "objectBoundingBox"
 
 attr :: forall r i. AttrName -> String -> IProp r i
 attr = coe Core.attr
@@ -226,14 +17,14 @@ attr = coe Core.attr
     coe :: (AttrName -> String -> Prop i) -> AttrName -> String -> IProp r i
     coe = unsafeCoerce
 
-cx :: forall r i. Number -> IProp (cx :: Number | r) i
-cx = attr (AttrName "cx") <<< show
+cx :: forall r i. String -> IProp (cx :: Number | r) i
+cx = attr (AttrName "cx")
 
-cy :: forall r i. Number -> IProp (cy :: Number | r) i
-cy = attr (AttrName "cy") <<< show
+cy :: forall r i. String -> IProp (cy :: Number | r) i
+cy = attr (AttrName "cy")
 
-r :: forall s i. Number -> IProp (r :: Number | s) i
-r = attr (AttrName "r") <<< show
+r :: forall s i. String -> IProp (r :: Number | s) i
+r = attr (AttrName "r")
 
 viewBox :: forall r i. Number -> Number -> Number -> Number -> IProp (viewBox :: String | r) i
 viewBox x' y' w' h' = attr (AttrName "viewBox") (joinWith " " $ map show [x', y', w', h'])
@@ -246,44 +37,44 @@ preserveAspectRatio align slice =
       Nothing -> "none"
       Just align' -> joinWith "" $ ["x", printAlign align'.x, "Y", printAlign align'.y]
 
-rx :: forall r i. Number -> IProp (rx :: Number | r) i
-rx = attr (AttrName "rx") <<< show
+rx :: forall r i. String -> IProp (rx :: Number | r) i
+rx = attr (AttrName "rx")
 
-ry :: forall r i. Number -> IProp (ry :: Number | r) i
-ry = attr (AttrName "ry") <<< show
+ry :: forall r i. String -> IProp (ry :: Number | r) i
+ry = attr (AttrName "ry")
 
-width :: forall r i. Number -> IProp (width :: Number | r) i
-width = attr (AttrName "width") <<< show
+width :: forall r i. String -> IProp (width :: Number | r) i
+width = attr (AttrName "width")
 
-height :: forall r i. Number -> IProp (height :: Number | r) i
-height = attr (AttrName "height") <<< show
+height :: forall r i. String -> IProp (height :: Number | r) i
+height = attr (AttrName "height")
 
-x :: forall r i. Number -> IProp (x :: Number | r) i
-x = attr (AttrName "x") <<< show
+x :: forall r i. String -> IProp (x :: Number | r) i
+x = attr (AttrName "x")
 
-y :: forall r i. Number -> IProp (y :: Number | r) i
-y = attr (AttrName "y") <<< show
+y :: forall r i. String -> IProp (y :: Number | r) i
+y = attr (AttrName "y")
 
-x1 :: forall r i. Number -> IProp (x1 :: Number | r) i
-x1 = attr (AttrName "x1") <<< show
+x1 :: forall r i. String -> IProp (x1 :: Number | r) i
+x1 = attr (AttrName "x1")
 
-y1 :: forall r i. Number -> IProp (y1 :: Number | r) i
-y1 = attr (AttrName "y1") <<< show
+y1 :: forall r i. String -> IProp (y1 :: Number | r) i
+y1 = attr (AttrName "y1")
 
-x2 :: forall r i. Number -> IProp (x2 :: Number | r) i
-x2 = attr (AttrName "x2") <<< show
+x2 :: forall r i. String -> IProp (x2 :: Number | r) i
+x2 = attr (AttrName "x2")
 
-y2 :: forall r i. Number -> IProp (y2 :: Number | r) i
-y2 = attr (AttrName "y2") <<< show
+y2 :: forall r i. String -> IProp (y2 :: Number | r) i
+y2 = attr (AttrName "y2")
 
 stroke :: forall r i. PaintServer -> IProp (stroke :: String | r) i
-stroke = attr (AttrName "stroke") <<< printPaintServer
+stroke = attr (AttrName "stroke") <<< show
 
 strokeLinecap :: forall r i. StrokeLinecap -> IProp (strokeLinecap :: String | r) i
-strokeLinecap = attr (AttrName "stroke-linecap") <<< printStrokeLinecap
+strokeLinecap = attr (AttrName "stroke-linecap") <<< show
 
 fill :: forall r i. PaintServer -> IProp (fill :: String | r) i
-fill = attr (AttrName "fill") <<< printPaintServer
+fill = attr (AttrName "fill") <<< show
 
 transform :: forall r i . Array Transform -> IProp (transform :: String | r) i
 transform = attr (AttrName "transform") <<< joinWith " " <<< map printTransform
@@ -307,17 +98,17 @@ class_ = attr (AttrName "class")
 id :: forall r i . String -> IProp (id :: String | r) i
 id = attr (AttrName "id")
 
-markerWidth :: forall r i. Number -> IProp (markerWidth :: Number | r) i
-markerWidth = attr (AttrName "markerWidth") <<< show
+markerWidth :: forall r i. String -> IProp (markerWidth :: Number | r) i
+markerWidth = attr (AttrName "markerWidth")
 
-markerHeight :: forall r i. Number -> IProp (markerHeight :: Number | r) i
-markerHeight = attr (AttrName "markerHeight") <<< show
+markerHeight :: forall r i. String -> IProp (markerHeight :: Number | r) i
+markerHeight = attr (AttrName "markerHeight")
 
-refX :: forall r i. Number -> IProp (refX :: Number | r) i
-refX = attr (AttrName "refX") <<< show
+refX :: forall r i. String -> IProp (refX :: Number | r) i
+refX = attr (AttrName "refX")
 
-refY :: forall r i. Number -> IProp (refY :: Number | r) i
-refY = attr (AttrName "refY") <<< show
+refY :: forall r i. String -> IProp (refY :: Number | r) i
+refY = attr (AttrName "refY")
 
 orient :: forall r i. Orient -> IProp (orient :: String | r) i
 orient = attr (AttrName "orient") <<< printOrient
@@ -325,8 +116,8 @@ orient = attr (AttrName "orient") <<< printOrient
 markerUnits :: forall r i. MarkerUnit -> IProp (markerUnits :: String | r) i
 markerUnits = attr (AttrName "markerUnits") <<< printMarkerUnit
 
-strokeWidth :: forall r i. Number -> IProp (strokeWidth :: Number | r) i
-strokeWidth = attr (AttrName "stroke-width") <<< show
+strokeWidth :: forall r i. String -> IProp (strokeWidth :: Number | r) i
+strokeWidth = attr (AttrName "stroke-width")
 
 markerStart :: forall r i. String -> IProp (markerStart :: String | r) i
 markerStart = attr (AttrName "marker-start")
@@ -341,13 +132,19 @@ href :: forall r i. String -> IProp (href :: String | r) i
 href = attr (AttrName "href")
 
 patternContentUnits :: forall r i. PatternUnits -> IProp (patternContentUnits :: String | r) i
-patternContentUnits = attr (AttrName "patternContentUnits") <<< printPatternUnits
+patternContentUnits = attr (AttrName "patternContentUnits") <<< show
 
 patternTransform :: forall r i. Transform -> IProp (patternTransform :: String | r) i
 patternTransform = attr (AttrName "patternTransform") <<< printTransform
 
 patternUnits :: forall r i. PatternUnits -> IProp (patternUnits :: String | r) i
-patternUnits = attr (AttrName "patternUnits") <<< printPatternUnits
+patternUnits = attr (AttrName "patternUnits") <<< show
+
+points :: forall r i. Array Point -> IProp (points :: String | r) i
+points = attr (AttrName "points") <<< show
+
+pathLength :: forall r i. Number -> IProp (points :: String | r) i
+pathLength = attr (AttrName "pathLenth") <<< show
 
 --------------------------------------------------------------------------------
 

--- a/src/Svg/Attributes.purs
+++ b/src/Svg/Attributes.purs
@@ -201,6 +201,13 @@ printStrokeLinecap Butt = "butt"
 printStrokeLinecap Round = "round"
 printStrokeLinecap Square = "square"
 
+data PatternUnits
+  = PatternUnitsUserSpaceOnUse
+  | ObjectBoundingBox
+printPatternUnits :: PatternUnits -> String
+printPatternUnits PatternUnitsUserSpaceOnUse = "userSpaceOnUse"
+printPatternUnits ObjectBoundingBox = "objectBoundingBox"
+
 attr :: forall r i. AttrName -> String -> IProp r i
 attr = coe Core.attr
   where
@@ -317,6 +324,18 @@ markerMid = attr (AttrName "marker-mid")
 
 markerEnd :: forall r i. String -> IProp (markerEnd :: String | r) i
 markerEnd = attr (AttrName "marker-end")
+
+href :: forall r i. String -> IProp (href :: String | r) i
+href = attr (AttrName "href")
+
+patternContentUnits :: forall r i. PatternUnits -> IProp (patternContentUnits :: String | r) i
+patternContentUnits = attr (AttrName "patternContentUnits") <<< printPatternUnits
+
+patternTransform :: forall r i. Transform -> IProp (patternTransform :: String | r) i
+patternTransform = attr (AttrName "patternTransform") <<< printTransform
+
+patternUnits :: forall r i. PatternUnits -> IProp (patternUnits :: String | r) i
+patternUnits = attr (AttrName "patternUnits") <<< printPatternUnits
 
 --------------------------------------------------------------------------------
 

--- a/src/Svg/Attributes.purs
+++ b/src/Svg/Attributes.purs
@@ -15,8 +15,8 @@ data Color = RGB Int Int Int
            | RGBA Int Int Int Number
 
 printColor :: Maybe Color -> String
-printColor (Just (RGB r g b)) = "rgb(" <> (joinWith "," $ map show [r, g, b]) <> ")"
-printColor (Just (RGBA r g b o)) = "rgba(" <> (joinWith "," $ map show [r, g, b]) <> "," <> show o <> ")"
+printColor (Just (RGB r' g' b')) = "rgb(" <> (joinWith "," $ map show [r', g', b']) <> ")"
+printColor (Just (RGBA r' g' b' o')) = "rgba(" <> (joinWith "," $ map show [r', g', b']) <> "," <> show o' <> ")"
 printColor Nothing = "None"
 
 data Transform
@@ -135,13 +135,13 @@ printBaseline TextAfterEdge = "text-after-edge"
 printBaseline TextBeforeEdge = "text-before-edge"
 
 printTransform :: Transform -> String
-printTransform (Matrix a b c d e f) =
-  "matrix(" <> (joinWith "," $ map show [a, b, c, d, e, f]) <> ")"
-printTransform (Translate x y) = "translate(" <> (joinWith "," $ map show [x, y]) <> ")"
-printTransform (Scale x y) = "scale(" <> (joinWith "," $ map show [x, y]) <> ")"
-printTransform (Rotate a x y) = "rotate(" <> (joinWith "," $ map show [a, x, y]) <> ")"
-printTransform (SkewX a) = "skewX(" <> show a <> ")"
-printTransform (SkewY a) = "skewY(" <> show a <> ")"
+printTransform (Matrix a' b' c' d' e' f') =
+  "matrix(" <> (joinWith "," $ map show [a', b', c', d', e', f']) <> ")"
+printTransform (Translate x' y') = "translate(" <> (joinWith "," $ map show [x', y']) <> ")"
+printTransform (Scale x' y') = "scale(" <> (joinWith "," $ map show [x', y']) <> ")"
+printTransform (Rotate a' x' y') = "rotate(" <> (joinWith "," $ map show [a', x', y']) <> ")"
+printTransform (SkewX a') = "skewX(" <> show a' <> ")"
+printTransform (SkewY a') = "skewY(" <> show a' <> ")"
 
 data D = Rel Command | Abs Command
 printD :: D -> String
@@ -161,20 +161,20 @@ data Command
   | Z
 
 printCommand :: Command -> {command :: String, params :: String}
-printCommand (M x y) = {command: "m", params: joinWith "," $ map show [x, y]}
-printCommand (L x y) = {command: "l", params: joinWith "," $ map show [x, y]}
-printCommand (C x1 y1 x2 y2 x y) =
-  {command: "c" , params: joinWith "," $ map show [x1, y1, x2, y2, x, y]}
-printCommand (S x2 y2 x y) =
-  {command: "s" , params: joinWith "," $ map show [x2, y2, x, y]}
-printCommand (Q x1 y1 x y) =
-  {command: "q" , params: joinWith "," $ map show [x1, y1, x, y]}
-printCommand (T x y) = {command: "t", params: joinWith "," $ map show [x, y]}
-printCommand (A rx ry rot large sweep x y) =
+printCommand (M x' y') = {command: "m", params: joinWith "," $ map show [x', y']}
+printCommand (L x' y') = {command: "l", params: joinWith "," $ map show [x', y']}
+printCommand (C x1' y1' x2' y2' x' y') =
+  {command: "c" , params: joinWith "," $ map show [x1', y1', x2', y2', x', y']}
+printCommand (S x2' y2' x' y') =
+  {command: "s" , params: joinWith "," $ map show [x2', y2', x', y']}
+printCommand (Q x1' y1' x' y') =
+  {command: "q" , params: joinWith "," $ map show [x1', y1', x', y']}
+printCommand (T x' y') = {command: "t", params: joinWith "," $ map show [x', y']}
+printCommand (A rx' ry' rot large sweep x' y') =
   {command: "a", params: joinWith ","
-                 $ map show [ rx, ry, rot ]
+                 $ map show [ rx', ry', rot ]
                  <> [ large_flag, sweep_flag ]
-                 <> map show [ x, y ]}
+                 <> map show [ x', y' ]}
   where
   large_flag = if large then "0" else "1"
   sweep_flag = if sweep then "0" else "1"
@@ -192,6 +192,15 @@ printMeetOrSlice :: MeetOrSlice -> String
 printMeetOrSlice Meet = "meet"
 printMeetOrSlice Slice = "slice"
 
+data StrokeLinecap
+  = Butt
+  | Round
+  | Square
+printStrokeLinecap :: StrokeLinecap -> String
+printStrokeLinecap Butt = "butt"
+printStrokeLinecap Round = "round"
+printStrokeLinecap Square = "square"
+
 attr :: forall r i. AttrName -> String -> IProp r i
 attr = coe Core.attr
   where
@@ -208,7 +217,7 @@ r :: forall s i. Number -> IProp (r :: Number | s) i
 r = attr (AttrName "r") <<< show
 
 viewBox :: forall r i. Number -> Number -> Number -> Number -> IProp (viewBox :: String | r) i
-viewBox x y w h = attr (AttrName "viewBox") (joinWith " " $ map show [x, y, w, h])
+viewBox x' y' w' h' = attr (AttrName "viewBox") (joinWith " " $ map show [x', y', w', h'])
 
 preserveAspectRatio :: forall r i. Maybe {x :: Align, y :: Align} -> MeetOrSlice -> IProp (preserveAspectRatio :: String | r) i
 preserveAspectRatio align slice =
@@ -216,7 +225,7 @@ preserveAspectRatio align slice =
   where
     align_str = case align of
       Nothing -> "none"
-      Just {x, y} -> joinWith "" $ ["x", printAlign x, "Y", printAlign y]
+      Just align' -> joinWith "" $ ["x", printAlign align'.x, "Y", printAlign align'.y]
 
 rx :: forall r i. Number -> IProp (rx :: Number | r) i
 rx = attr (AttrName "rx") <<< show
@@ -250,6 +259,9 @@ y2 = attr (AttrName "y2") <<< show
 
 stroke :: forall r i. Maybe Color -> IProp (stroke :: String | r) i
 stroke = attr (AttrName "stroke") <<< printColor
+
+strokeLinecap :: forall r i. StrokeLinecap -> IProp (strokeLinecap :: String | r) i
+strokeLinecap = attr (AttrName "stroke-linecap") <<< printStrokeLinecap
 
 fill :: forall r i. Maybe Color -> IProp (fill :: String | r) i
 fill = attr (AttrName "fill") <<< printColor

--- a/src/Svg/Attributes.purs
+++ b/src/Svg/Attributes.purs
@@ -14,10 +14,22 @@ import Unsafe.Coerce (unsafeCoerce)
 data Color = RGB Int Int Int
            | RGBA Int Int Int Number
 
-printColor :: Maybe Color -> String
-printColor (Just (RGB r' g' b')) = "rgb(" <> (joinWith "," $ map show [r', g', b']) <> ")"
-printColor (Just (RGBA r' g' b' o')) = "rgba(" <> (joinWith "," $ map show [r', g', b']) <> "," <> show o' <> ")"
-printColor Nothing = "None"
+printColor :: Color -> String
+printColor (RGB r' g' b') = "rgb(" <> (joinWith "," $ map show [r', g', b']) <> ")"
+printColor (RGBA r' g' b' o') = "rgba(" <> (joinWith "," $ map show [r', g', b']) <> "," <> show o' <> ")"
+
+data PaintServer
+  = PaintNone
+  | PaintColor Color
+  | Pattern String
+  | Gradient String
+  | Hatch String
+printPaintServer :: PaintServer -> String
+printPaintServer PaintNone = "None"
+printPaintServer (PaintColor color) = printColor color
+printPaintServer (Pattern pattern) = pattern
+printPaintServer (Gradient gradient) = gradient
+printPaintServer (Hatch hatch) = hatch
 
 data Transform
   = Matrix Number Number Number Number Number Number
@@ -264,14 +276,14 @@ x2 = attr (AttrName "x2") <<< show
 y2 :: forall r i. Number -> IProp (y2 :: Number | r) i
 y2 = attr (AttrName "y2") <<< show
 
-stroke :: forall r i. Maybe Color -> IProp (stroke :: String | r) i
-stroke = attr (AttrName "stroke") <<< printColor
+stroke :: forall r i. PaintServer -> IProp (stroke :: String | r) i
+stroke = attr (AttrName "stroke") <<< printPaintServer
 
 strokeLinecap :: forall r i. StrokeLinecap -> IProp (strokeLinecap :: String | r) i
 strokeLinecap = attr (AttrName "stroke-linecap") <<< printStrokeLinecap
 
-fill :: forall r i. Maybe Color -> IProp (fill :: String | r) i
-fill = attr (AttrName "fill") <<< printColor
+fill :: forall r i. PaintServer -> IProp (fill :: String | r) i
+fill = attr (AttrName "fill") <<< printPaintServer
 
 transform :: forall r i . Array Transform -> IProp (transform :: String | r) i
 transform = attr (AttrName "transform") <<< joinWith " " <<< map printTransform

--- a/src/Svg/Attributes.purs
+++ b/src/Svg/Attributes.purs
@@ -309,6 +309,12 @@ markerUnits = attr (AttrName "markerUnits") <<< printMarkerUnit
 strokeWidth :: forall r i. Number -> IProp (strokeWidth :: Number | r) i
 strokeWidth = attr (AttrName "stroke-width") <<< show
 
+markerStart :: forall r i. String -> IProp (markerStart :: String | r) i
+markerStart = attr (AttrName "marker-start")
+
+markerMid :: forall r i. String -> IProp (markerMid :: String | r) i
+markerMid = attr (AttrName "marker-mid")
+
 markerEnd :: forall r i. String -> IProp (markerEnd :: String | r) i
 markerEnd = attr (AttrName "marker-end")
 

--- a/src/Svg/Core.purs
+++ b/src/Svg/Core.purs
@@ -1,17 +1,16 @@
 module Core where
 -- Like Halogen.HTML.Core
 
-import Prelude
 import Data.Maybe (Maybe(..))
 import Halogen.HTML.Core (HTML, Prop(Attribute), Namespace(Namespace), AttrName(AttrName))
 import Halogen.VDom (ElemName, VDom(Elem))
 import Unsafe.Coerce (unsafeCoerce)
 
-ns :: Maybe Namespace
-ns = Just $ Namespace "http://www.w3.org/2000/svg"
+ns :: Namespace
+ns = Namespace "http://www.w3.org/2000/svg"
 
 element :: forall p i. ElemName -> Array (Prop i) -> Array (HTML p i) -> HTML p i
-element = coe (\name props children -> Elem ns name props children)
+element = coe (\name props children -> Elem (Just ns) name props children)
   where
     coe :: (ElemName -> Array (Prop i) -> Array (VDom (Array (Prop i)) p) -> VDom (Array (Prop i)) p)
         -> ElemName -> Array (Prop i) -> Array (HTML p i) -> HTML p i

--- a/src/Svg/Elements.purs
+++ b/src/Svg/Elements.purs
@@ -36,6 +36,9 @@ rect props = element (ElemName "rect") props []
 path :: forall p i. Leaf I.SVGpath p i
 path props = element (ElemName "path") props []
 
+polyline :: forall p i. Leaf I.SVGpolyline p i
+polyline props = element (ElemName "polyline") props []
+
 line :: forall p i. Leaf I.SVGline p i
 line props = element (ElemName "line") props []
 

--- a/src/Svg/Elements.purs
+++ b/src/Svg/Elements.purs
@@ -51,6 +51,9 @@ defs = element $ ElemName "defs"
 marker :: forall p i. Node I.SVGmarker p i
 marker = element $ ElemName "marker"
 
+pattern :: forall p i. Node I.SVGPattern p i
+pattern = element $ ElemName "pattern"
+
 --------------------------------------------------------------------------------
 
 animate :: forall p i. Leaf I.SVGanimate p i

--- a/src/Svg/Elements/Keyed.purs
+++ b/src/Svg/Elements/Keyed.purs
@@ -1,0 +1,35 @@
+module Svg.Elements.Keyed where
+
+import Prelude
+
+import Core as Core
+
+import Data.Tuple (Tuple)
+import Halogen.HTML.Core (ElemName(ElemName), HTML)
+import Halogen.HTML.Elements (keyedNS)
+import Halogen.HTML.Properties (IProp)
+import Svg.Indexed as I
+
+-- Not exported by Halogen.HTML.Elements.Keyed
+type KeyedNode r w i
+   = Array (IProp r i)
+     -> Array (Tuple String (HTML w i))
+     -> HTML w i
+
+svg :: forall p i. KeyedNode I.SVGsvg p i
+svg = keyedNS Core.ns $ ElemName "svg"
+
+g :: forall p i. KeyedNode I.SVGg p i
+g = keyedNS Core.ns $ ElemName "g"
+
+text :: forall p i. KeyedNode I.SVGtext p i
+text = keyedNS Core.ns (ElemName "text")
+
+foreignObject :: forall p i . KeyedNode I.SVGforeignObject p i
+foreignObject = keyedNS Core.ns (ElemName "foreignObject")
+
+marker :: forall p i. KeyedNode I.SVGmarker p i
+marker = keyedNS Core.ns (ElemName "marker")
+
+defs :: forall p i. Array (Tuple String (HTML p i)) -> HTML p i
+defs = keyedNS Core.ns (ElemName "defs") []

--- a/src/Svg/Indexed.purs
+++ b/src/Svg/Indexed.purs
@@ -80,6 +80,11 @@ type SVGpath = MarkerAttributes (GlobalAttributes
   , transform :: String
   ))
 
+type SVGpolyline = MarkerAttributes (GlobalAttributes
+  ( points :: String
+  , pathLength :: Number
+  ))
+
 type SVGline = MarkerAttributes (GlobalAttributes
   ( x1 :: Number
   , y1 :: Number

--- a/src/Svg/Indexed.purs
+++ b/src/Svg/Indexed.purs
@@ -87,6 +87,7 @@ type SVGline = MarkerAttributes (GlobalAttributes
   , y2 :: Number
   , transform :: String
   , strokeWidth :: Number
+  , strokeLinecap :: String
   ))
 
 type SVGtext = GlobalAttributes

--- a/src/Svg/Indexed.purs
+++ b/src/Svg/Indexed.purs
@@ -116,6 +116,19 @@ type SVGmarker = (PresentationAttributes (StyleAttributes (CoreAttributes
   , markerUnits :: String
   ))))
 
+type SVGPattern = GlobalAttributes
+  ( height :: Number
+  , width :: Number
+  , href :: String
+  , patternContentUnits :: String
+  , patternTransform :: String
+  , patternUnits :: String
+  , preserveAspectRatio :: String
+  , viewBox :: String
+  , x :: Number
+  , y :: Number
+  )
+
 --------------------------------------------------------------------------------
 
 type AnimationAttributes r = GlobalAttributes

--- a/src/Svg/Types.purs
+++ b/src/Svg/Types.purs
@@ -1,0 +1,225 @@
+module Svg.Types where
+
+import Prelude
+import Data.String (joinWith, toUpper)
+
+data Color = RGB Int Int Int
+           | RGBA Int Int Int Number
+
+printColor :: Color -> String
+printColor (RGB r' g' b') = "rgb(" <> (joinWith "," $ map show [r', g', b']) <> ")"
+printColor (RGBA r' g' b' o') = "rgba(" <> (joinWith "," $ map show [r', g', b']) <> "," <> show o' <> ")"
+
+data PaintServer
+  = PaintNone
+  | PaintColor Color
+  | Pattern String
+  | Gradient String
+  | Hatch String
+
+instance showPaintServer :: Show PaintServer where
+  show PaintNone = "None"
+  show (PaintColor color) = printColor color
+  show (Pattern pattern) = pattern
+  show (Gradient gradient) = gradient
+  show (Hatch hatch) = hatch
+
+data Transform
+  = Matrix Number Number Number Number Number Number
+  | Translate Number Number
+  | Scale Number Number
+  | Rotate Number Number Number
+  | SkewX Number
+  | SkewY Number
+
+printTransform :: Transform -> String
+printTransform (Matrix a' b' c' d' e' f') =
+  "matrix(" <> (joinWith "," $ map show [a', b', c', d', e', f']) <> ")"
+printTransform (Translate x' y') = "translate(" <> (joinWith "," $ map show [x', y']) <> ")"
+printTransform (Scale x' y') = "scale(" <> (joinWith "," $ map show [x', y']) <> ")"
+printTransform (Rotate a' x' y') = "rotate(" <> (joinWith "," $ map show [a', x', y']) <> ")"
+printTransform (SkewX a') = "skewX(" <> show a' <> ")"
+printTransform (SkewY a') = "skewY(" <> show a' <> ")"
+
+
+data TextAnchor = Start | AnchorMiddle | End
+
+printTextAnchor :: TextAnchor -> String
+printTextAnchor Start = "start"
+printTextAnchor AnchorMiddle = "middle"
+printTextAnchor End = "end"
+
+data CSSLength
+  = Cm Number
+  | Mm Number
+  | Inches Number
+  | Px Number
+  | Pt Number
+  | Pc Number
+  | Em Number
+  | Ex Number
+  | Rem Number
+  | Vw Number
+  | Vh Number
+  | Vmin Number
+  | Vmax Number
+  | Pct Number
+  | Nil
+
+instance showCSSLength :: Show CSSLength where
+  show (Cm i) = (show i) <> "cm"
+  show (Mm i) = (show i) <> "mm"
+  show (Inches i) = (show i) <> "in"
+  show (Px i) = (show i) <> "px"
+  show (Pt i) = (show i) <> "pt"
+  show (Pc i) = (show i) <> "pc"
+  show (Em i) = (show i) <> "em"
+  show (Ex i) = (show i) <> "ex"
+  show (Rem i) = (show i) <> "rem"
+  show (Vw i) = (show i) <> "vw"
+  show (Vh i) = (show i) <> "vh"
+  show (Vmin i) = (show i) <> "vmin"
+  show (Vmax i) = (show i) <> "vmax"
+  show (Pct i) = (show i) <> "%"
+  show Nil = "0"
+
+data FontSize
+  = XXSmall
+  | XSmall
+  | Small
+  | Medium
+  | Large
+  | XLarge
+  | XXLarge
+  | Smaller
+  | Larger
+  | FontSizeLength CSSLength
+
+instance showFontSize :: Show FontSize where
+  show XXSmall = "xx-small"
+  show XSmall = "x-small"
+  show Small = "small"
+  show Medium = "medium"
+  show Large = "large"
+  show XLarge = "x-large"
+  show XXLarge = "xx-large"
+  show Smaller = "smaller"
+  show Larger = "larger"
+  show (FontSizeLength l) = show l
+
+data Orient
+  = AutoOrient
+  | AutoStartReverse
+
+instance showOrient :: Show Orient where
+  show AutoOrient = "auto"
+  show AutoStartReverse = "auto-start-reverse"
+
+printOrient :: Orient -> String
+printOrient AutoOrient = "auto"
+printOrient AutoStartReverse = "auto-start-reverse"
+
+data MarkerUnit
+  = UserSpaceOnUse
+  | StrokeWidth
+
+instance showMarkerUnit :: Show MarkerUnit where
+  show UserSpaceOnUse = "userSpaceOnUse"
+  show StrokeWidth = "strokeWidth"
+
+printMarkerUnit :: MarkerUnit -> String
+printMarkerUnit UserSpaceOnUse = "userSpaceOnUse"
+printMarkerUnit StrokeWidth = "strokeWidth"
+
+data Baseline
+  = Auto | UseScript | NoChange | ResetSize | Ideographic | Alphabetic | Hanging
+  | Mathematical | Central | BaselineMiddle | TextAfterEdge | TextBeforeEdge
+
+printBaseline :: Baseline -> String
+printBaseline Auto = "auto"
+printBaseline UseScript = "use-script"
+printBaseline NoChange = "no-change"
+printBaseline ResetSize = "reset-size"
+printBaseline Ideographic = "ideographic"
+printBaseline Alphabetic = "alphabetic"
+printBaseline Hanging = "hanging"
+printBaseline Mathematical = "mathematical"
+printBaseline Central = "central"
+printBaseline BaselineMiddle = "middle"
+printBaseline TextAfterEdge = "text-after-edge"
+printBaseline TextBeforeEdge = "text-before-edge"
+
+data D = Rel Command | Abs Command
+printD :: D -> String
+printD (Abs cmd) = (toUpper p.command) <> p.params
+  where p = printCommand cmd
+printD (Rel cmd) = p.command <> p.params
+  where p = printCommand cmd
+
+data Command
+  = M Number Number
+  | L Number Number
+  | C Number Number Number Number Number Number
+  | S Number Number Number Number
+  | Q Number Number Number Number
+  | T Number Number
+  | A Number Number Number Boolean Boolean Number Number
+  | Z
+
+printCommand :: Command -> {command :: String, params :: String}
+printCommand (M x' y') = {command: "m", params: joinWith "," $ map show [x', y']}
+printCommand (L x' y') = {command: "l", params: joinWith "," $ map show [x', y']}
+printCommand (C x1' y1' x2' y2' x' y') =
+  {command: "c" , params: joinWith "," $ map show [x1', y1', x2', y2', x', y']}
+printCommand (S x2' y2' x' y') =
+  {command: "s" , params: joinWith "," $ map show [x2', y2', x', y']}
+printCommand (Q x1' y1' x' y') =
+  {command: "q" , params: joinWith "," $ map show [x1', y1', x', y']}
+printCommand (T x' y') = {command: "t", params: joinWith "," $ map show [x', y']}
+printCommand (A rx' ry' rot large sweep x' y') =
+  {command: "a", params: joinWith ","
+                 $ map show [ rx', ry', rot ]
+                 <> [ large_flag, sweep_flag ]
+                 <> map show [ x', y' ]}
+  where
+  large_flag = if large then "0" else "1"
+  sweep_flag = if sweep then "0" else "1"
+printCommand Z = {command: "z", params: ""}
+
+data Align = Min | Mid | Max
+
+printAlign :: Align -> String
+printAlign Min = "Min"
+printAlign Mid = "Mid"
+printAlign Max = "Max"
+
+data MeetOrSlice = Meet | Slice
+printMeetOrSlice :: MeetOrSlice -> String
+printMeetOrSlice Meet = "meet"
+printMeetOrSlice Slice = "slice"
+
+data StrokeLinecap
+  = Butt
+  | Round
+  | Square
+
+instance showStrokeLinecap :: Show StrokeLinecap where
+  show Butt = "butt"
+  show Round = "round"
+  show Square = "square"
+
+data PatternUnits
+  = PatternUnitsUserSpaceOnUse
+  | ObjectBoundingBox
+
+instance showPatternUnits :: Show PatternUnits where
+  show PatternUnitsUserSpaceOnUse = "userSpaceOnUse"
+  show ObjectBoundingBox = "objectBoundingBox"
+
+data Point = Point Number Number
+
+instance showPoint :: Show Point where
+  show (Point a b) = show a <> "," <> show b
+
+printPoints :: Array Point -> String
+printPoints points = joinWith " " $ map show points

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,7 +1,7 @@
 module Test.Main where
 
 import Prelude
-import Halogen as H
+import Halogen.HTML (HTML)
 import Svg.Attributes as SA
 import Svg.Elements as SE
 import Effect (Effect)
@@ -9,7 +9,7 @@ import Effect.Console (log)
 
 -- smoke test
 
-render :: forall t1 t2 t3 . t1 -> H.HTML t2 t3
+render :: forall t1 t2 t3 . t1 -> HTML t2 t3
 render state =
   SE.svg [ SA.viewBox 0.0 0.0 100.0 100.0 ] [ SE.circle [ SA.r 10.0 ] ]
 


### PR DESCRIPTION
I totally understand if you don't want to merge breaking changes :)


Length-argument attributes take String
    
String arguments allow for non-number values (e.g. percentages).
An alternative is to create union types, but this leads to user code specifying (for example) marker position looking like:
`SA.refX $ SA.MarkerPositionLengthPercentage $ SA.Length $ SA.Px 5.0`
To differentiate length and percentage within a length-percentage argument, the `LengthPercentage` type is needed, and as `refX` can take
[`<length-percentage> | <number> | left | center | right`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/refX)
it needs its own union type `MarkerPosition`. I prefer just passing a String:
`SA.refX "5.0px"`
    
`fill` and `stroke` now take a `PaintServer` which enables using patterns and gradients.

`polylines` element added
Types moved from Attributes.purs to Types.purs